### PR TITLE
move catch in switchMap avoiding ending the effect

### DIFF
--- a/client/imports/demo/products.effects.ts
+++ b/client/imports/demo/products.effects.ts
@@ -25,7 +25,8 @@ export class ProductsEffects {
   @Effect() addProduct$ = this.updates$
     .whenAction(ProductsActions.ADD_PRODUCTS)
     .map(toPayload)
-    .switchMap((product: Product) => this.productsService.addProduct(product))
-    .map(productId => ({type: ProductsActions.ADD_PRODUCT_SUCCESS, payload: productId}))
-    .catch(e => (Observable.of({ type: ProductsActions.ADD_PRODUCT_FAIL, payload: e })))
+    .switchMap((product: Product) => this.productsService.addProduct(product)
+      .map(productId => ({type: ProductsActions.ADD_PRODUCT_SUCCESS, payload: productId}))
+      .catch(e => (Observable.of({ type: ProductsActions.ADD_PRODUCT_FAIL, payload: e })))
+    );
 }


### PR DESCRIPTION
The catch on the effect will end the effect, and return an observable of the error.

However, when you catch the in switchMap, you're returning the action for the outer effect observable to emit, which won't stop the effect.